### PR TITLE
[Feature] - Sort languages alphabetically

### DIFF
--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -79,6 +79,7 @@ export const useData = (options: IOptions) => {
       isLoading.current = false;
       issueCount.current = response.data.search.issueCount;
       languages.current = Array.from(new Set([...languages.current, ...languagesFromRepository]))
+        .sort((prev, next) => prev.localeCompare(next));
 
     })();
 


### PR DESCRIPTION
### Pull Request

### Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #12 

### Description:

Sorts languages alphabetically, and continues to do so when new languages are added.
> This could have an additional refactor to dispose of the `Array.from(Set(...))` usage and move towards a more chainable approach with `.filter` that would then lead into `.sort` naturally - but I believe that is a matter of preference on your end as it's maintainer, especially with performance in mind.

### Questions
