### PR TITLE
feat: new filter for unassigned issues

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -59,6 +59,28 @@ export const Card = (props: ICardProps) => {
           </a>
         </div>
       </div>
+      <div className="issue-meta-data flex items-center flex-wrap">
+        <div className="issue-assignee flex items-center">
+          {data.assignees.totalCount > 0 && (
+            <>
+              <div className="issue-assigned text-sm">Assigned to&nbsp;</div>
+              <img
+                className="inline-block rounded-full ring-2 ring-white"
+                height={20}
+                width={20}
+                src={data.assignees.nodes[0].avatarUrl}
+                alt={data.assignees.nodes[0].login}
+              />
+              <a
+                className="pl-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-600 font-semibold text-blue-600 hover:underline"
+                href={data.assignees.nodes[0].url}
+              >
+                {data.assignees.nodes[0].login}
+              </a>
+            </>
+          )}
+        </div>
+      </div>
       <Labels list={data.labels.nodes} />
       <div className="issue-body my-2 text-sm line-clamp-3">
         <RenderMarkdown markdownText={data.body} />

--- a/src/components/Forms/FilterForm.tsx
+++ b/src/components/Forms/FilterForm.tsx
@@ -4,6 +4,7 @@ import { Select } from '../FormElements/Select';
 
 export interface FilterItems {
   goodFirstIssue: boolean;
+  unassignedIssue: boolean;
   language: string | undefined;
 }
 
@@ -40,6 +41,11 @@ export const FilterForm = (props: IFilterProps) => {
             label="Good First Issue"
             value={values.goodFirstIssue}
             setValue={(value) => setValue('goodFirstIssue', value)}
+          />
+          <Checkbox
+            label="Unassigned Issue"
+            value={values.unassignedIssue}
+            setValue={(value) => setValue('unassignedIssue', value)}
           />
         </div>
       </form>

--- a/src/components/Forms/FilterForm.tsx
+++ b/src/components/Forms/FilterForm.tsx
@@ -43,7 +43,7 @@ export const FilterForm = (props: IFilterProps) => {
             setValue={(value) => setValue('goodFirstIssue', value)}
           />
           <Checkbox
-            label="Unassigned Issue"
+            label="Unassigned"
             value={values.unassignedIssue}
             setValue={(value) => setValue('unassignedIssue', value)}
           />

--- a/src/lib/filter-issues.ts
+++ b/src/lib/filter-issues.ts
@@ -1,20 +1,22 @@
-import type { FilterItems } from "../components/Forms/FilterForm";
-import type { Issue } from "../types";
+import type { FilterItems } from '../components/Forms/FilterForm';
+import type { Issue } from '../types';
 
 export const FILTER_ISSUES = (filters: FilterItems) => {
   return (issue: Issue) => {
-    const { goodFirstIssue, language } = filters;
-    if (!goodFirstIssue && (!language || language === '__NONE')) {
+    const { goodFirstIssue, unassignedIssue, language } = filters;
+    if (!goodFirstIssue && !unassignedIssue && (!language || language === '__NONE')) {
       return true;
     }
 
     const issue_labels = (issue.labels.nodes || []).map((label) => label.name.toLowerCase()) || [];
+    const issue_total_assignees = issue.assignees.totalCount;
     const issue_repo_languages = (issue.repository.languages.nodes || []).map((lang) => lang.name.toLowerCase()) || [];
 
     if (
       (goodFirstIssue &&
         issue_labels.length > 0 &&
         (issue_labels.includes('good first issue') || issue_labels.includes('good-first-issue'))) ||
+      (unassignedIssue && issue_total_assignees == 0) ||
       (language && issue_repo_languages.length > 0 && issue_repo_languages.includes(language.toLowerCase()))
     ) {
       return true;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,7 @@ const Home: NextPage<{} & IContributorsProps> = (props) => {
   const { contributors } = props;
   const [filters, setFilters] = useState<FilterItems>({
     goodFirstIssue: false,
+    unassignedIssue: false,
     language: undefined,
   });
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,6 +10,10 @@ interface Author {
   avatarUrl: string;
   login: string;
 }
+interface Assignees {
+  totalCount: number;
+  nodes: Author[];
+}
 
 interface Label {
   name: string;
@@ -68,6 +72,7 @@ export interface Issue {
   createdAt: string;
   updatedAt: string;
   number: number;
+  assignees: Assignees;
   author: Author;
   labels: Node<Label>;
   repository: Repository;


### PR DESCRIPTION
### Pull Request
feat: new filter for unassigned issues

### Related Issue:

Closes #17

### Description:
- A new filter for unassigned issues only
- If the issue is already assigned, displays the assignee (only the first one)

### Screenshots:
New filter:
![A checkbox below "good first issue" filter that says "Unassigned"](https://i.ibb.co/Df0rrVJ/photo-2022-10-05-20-43-13.jpg)
An unassigned issue:
![Issue with no assignees](https://i.ibb.co/dbzSthn/photo-2022-10-05-20-31-03.jpg)

An assigned issue:
![Issue with one assignee](https://i.ibb.co/wgKzrWG/photo-2022-10-05-20-34-51.jpg)

### Questions
